### PR TITLE
Use test for checking regex match

### DIFF
--- a/src/palindromeChecker/index.js
+++ b/src/palindromeChecker/index.js
@@ -19,7 +19,7 @@ function palindrome(str) {
   const regex = /[a-z0-9]/;
 
   [...str.toLowerCase()].forEach((ch) => {
-    if (regex.exec(ch)) {
+    if (regex.test(ch)) {
       refinedStr += ch;
     }
   });


### PR DESCRIPTION
The use case in the palindrome function is only interested in if the
regex pattern exists. regex.test(str) does no more than that compared to
exec.